### PR TITLE
Drag and drop files from desktop

### DIFF
--- a/app/controller.js
+++ b/app/controller.js
@@ -16,6 +16,7 @@ require("./document/tools/ellipse_filled");
 require("./document/tools/ellipse_outline");
 require("./document/tools/fill");
 require("./document/tools/sample");
+require("./document/input/drag_and_drop");
 
 doc.on("start_rendering", () => send_sync("show_rendering_modal"));
 doc.on("end_rendering", () => send("close_modal"));

--- a/app/document/doc.js
+++ b/app/document/doc.js
@@ -1,5 +1,5 @@
 const libtextmode = require("../libtextmode/libtextmode");
-const { on, send, send_sync } = require("../senders");
+const { on, send, send_sync, open_box} = require("../senders");
 const events = require("events");
 const chat = require("./ui/chat");
 const path = require("path");
@@ -1154,8 +1154,25 @@ class TextModeDoc extends events.EventEmitter {
         this.start_rendering().then(() => this.emit("change_font", doc.font_name));
     }
 
-    async load_custom_font() {
-        const { bytes, filename } = await libtextmode.load_custom_font();
+    async load_custom_font({ file }) {
+        if (!file) {
+            const files = open_box({
+                filters: [{
+                    name: "Custom Font",
+                    extensions: [
+                        "f06", "f07", "f08", "f09", "f10", "f11", "f12", "f13",
+                        "f14", "f15","f16", "f17", "f18", "f19", "f20", "f21",
+                        "f22", "f23", "f24", "f25", "f26", "f27", "f28", "f29",
+                        "f30", "f31", "f32"
+                    ]
+                }]
+            });
+            if (files.length === 0) return;
+            file = files[0]
+        }
+
+        const { bytes, filename } = await libtextmode.load_custom_font(file);
+        console.log(bytes, filename)
         doc.font_name = path.parse(filename).name;
         doc.font_bytes = bytes;
         this.start_rendering().then(() => this.emit("change_font", doc.font_name));

--- a/app/document/input/drag_and_drop.js
+++ b/app/document/input/drag_and_drop.js
@@ -1,14 +1,17 @@
 const path = require('path');
-const { send } = require("../../senders");
+const { send, msg_box} = require("../../senders");
 const doc = require("../doc");
 const {open_reference_image} = require("../ui/ui");
 
-const document_extensions = [".ans", ".asc", ".diz", ".nfo", ".txt", ".xb", ".bin"]
+const document_extensions = [
+    ".ans", ".asc", ".diz", ".nfo", ".txt", ".xb", ".bin"
+]
 const reference_extensions = [".png", ".jpg", ".jpeg"]
 const font_extensions = [
-    ".f06", ".f07", ".f08", ".f09", ".f10", ".f11", ".f12", ".f13", ".f14", ".f15",
-    ".f16", ".f17", ".f18", ".f19", ".f20", ".f21", ".f22", ".f23", ".f24", ".f25",
-    ".f26", ".f27", ".f28", ".f29", ".f30", ".f31", ".f32"
+    ".f06", ".f07", ".f08", ".f09", ".f10", ".f11", ".f12",
+    ".f13", ".f14", ".f15", ".f16", ".f17", ".f18", ".f19",
+    ".f20", ".f21", ".f22", ".f23", ".f24", ".f25", ".f26",
+    ".f27", ".f28", ".f29", ".f30", ".f31", ".f32"
 ]
 
 document.addEventListener("DOMContentLoaded", (event) => {
@@ -26,11 +29,37 @@ document.addEventListener("DOMContentLoaded", (event) => {
         const ext = path.extname(file.name).toLowerCase();
 
         if (document_extensions.includes(ext)) {
-            send("open", file.path)
+            const choice = msg_box(
+                "Open file",
+                `Open ${file.name} in the editor.`,
+                {
+                    buttons: ["Open in New Window", "Replace Current File", "Cancel"],
+                });
+            if (choice === 0) {
+                send("open_file", {file: file.path})
+            } else if (choice === 1) {
+                doc.open(file.path)
+            }
         } else if (reference_extensions.includes(ext)) {
-            open_reference_image({file: file.path})
+            const choice = msg_box(
+                "Open Reference",
+                `Open ${file.name} as the current reference image.`,
+                {
+                    buttons: ["Open Reference", "Cancel"],
+                });
+            if (choice === 0) {
+                open_reference_image({file: file.path});
+            }
         } else if (font_extensions.includes(ext)) {
-            doc.load_custom_font({file: file.path});
+            const choice = msg_box(
+                "Load Font",
+                `Load file ${file.name} as the current font.`,
+                {
+                    buttons: ["Load Font", "Cancel"],
+                });
+            if (choice === 0) {
+                doc.load_custom_font({file: file.path});
+            }
         }
     });
 });

--- a/app/document/input/drag_and_drop.js
+++ b/app/document/input/drag_and_drop.js
@@ -1,0 +1,36 @@
+const path = require('path');
+const { send } = require("../../senders");
+const doc = require("../doc");
+const {open_reference_image} = require("../ui/ui");
+
+const document_extensions = [".ans", ".asc", ".diz", ".nfo", ".txt", ".xb", ".bin"]
+const reference_extensions = [".png", ".jpg", ".jpeg"]
+const font_extensions = [
+    ".f06", ".f07", ".f08", ".f09", ".f10", ".f11", ".f12", ".f13", ".f14", ".f15",
+    ".f16", ".f17", ".f18", ".f19", ".f20", ".f21", ".f22", ".f23", ".f24", ".f25",
+    ".f26", ".f27", ".f28", ".f29", ".f30", ".f31", ".f32"
+]
+
+document.addEventListener("DOMContentLoaded", (event) => {
+    document.body.addEventListener("dragover", event => {
+        event.preventDefault();
+    });
+
+    document.body.addEventListener("drop", event => {
+        event.preventDefault();
+
+        const files = event.dataTransfer.files;
+        if (files.length === 0) return;
+
+        const file = files[0];
+        const ext = path.extname(file.name).toLowerCase();
+
+        if (document_extensions.includes(ext)) {
+            send("open", file.path)
+        } else if (reference_extensions.includes(ext)) {
+            open_reference_image({file: file.path})
+        } else if (font_extensions.includes(ext)) {
+            doc.load_custom_font({file: file.path});
+        }
+    });
+});

--- a/app/document/ui/ui.js
+++ b/app/document/ui/ui.js
@@ -19,13 +19,16 @@ function set_var_px(name, value) {
     set_var(name, `${value}px`);
 }
 
-function open_reference_image() {
-    const files = open_box({ filters: [{ name: "Images", extensions: ["png", "jpg", "jpeg"] }] });
-    if (files) {
-        $("reference_image").style.backgroundImage = `url(${electron.nativeImage.createFromPath(files[0]).toDataURL()})`;
-        $("reference_image").style.opacity = 0.4;
-        send("enable_reference_image");
+function open_reference_image({ file }) {
+    if (!file) {
+        const files = open_box({ filters: [{ name: "Images", extensions: ["png", "jpg", "jpeg"] }] });
+        if (files.length === 0) return;
+        file = files[0]
     }
+
+    $("reference_image").style.backgroundImage = `url(${electron.nativeImage.createFromPath(file).toDataURL()})`;
+    $("reference_image").style.opacity = 0.4;
+    send("enable_reference_image");
 }
 
 function toggle_reference_image(visible) {
@@ -766,4 +769,4 @@ class Toolbar extends events.EventEmitter {
     }
 }
 
-module.exports = { statusbar: new StatusBar(), tools: new Tools(), toolbar: new Toolbar(), zoom_in, zoom_out, actual_size, canvas_zoom_toggle };
+module.exports = { statusbar: new StatusBar(), tools: new Tools(), toolbar: new Toolbar(), zoom_in, zoom_out, actual_size, canvas_zoom_toggle, open_reference_image};

--- a/app/libtextmode/libtextmode.js
+++ b/app/libtextmode/libtextmode.js
@@ -3,7 +3,7 @@ const { create_canvas, join_canvases } = require("./canvas");
 const { Ansi, encode_as_ansi } = require("./ansi");
 const { BinaryText, encode_as_bin } = require("./binary_text");
 const { XBin, encode_as_xbin } = require("./xbin");
-const { palette_4bit, has_base_palette } = require("./palette");
+const { palette_4bit } = require("./palette");
 const path = require("path");
 const { open_box } = require("../senders");
 const { current_date, resize_canvas, Textmode } = require("./textmode");
@@ -12,11 +12,6 @@ const fs = require("fs");
 const upng = require("upng-js");
 const { getSync } = require("@andreekeberg/imagedata");
 
-const document_types = {
-    ansi: { name: "ANSI Art", extensions: ["ans", "asc", "diz", "nfo", "txt"] },
-    xbin: { name: "XBin", extensions: ["xb"] },
-    bin: { name: "Binary Text", extensions: ["bin"] }
-}
 
 function read_bytes(bytes, file) {
     switch (path.extname(file).toLowerCase()) {
@@ -728,19 +723,13 @@ async function importFontFromImage() {
     }
 }
 
-async function load_custom_font() {
-    const file = open_box({
-        filters: [{ name: "Custom Font", extensions: ["f06", "f07", "f08", "f09", "f10", "f11", "f12", "f13", "f14", "f15", "f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23", "f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31", "f32"] }]
-    });
-
-    if (file) {
-        return new Promise((resolve) => {
-            fs.readFile(file[0], (err, bytes) => {
-                if (err) throw (`Error: ${file} not found!`);
-                resolve({ bytes: bytes, filename: file[0] });
-            });
+async function load_custom_font(file) {
+    return new Promise((resolve) => {
+        fs.readFile(file, (err, bytes) => {
+            if (err) throw (`Error: ${file} not found!`);
+            resolve({ bytes: bytes, filename: file });
         });
-    }
+    });
 }
 
 

--- a/app/menu.js
+++ b/app/menu.js
@@ -570,8 +570,6 @@ function font_menu_template(win) {
             { label: "Export font\u2026", id: "export_font", click(item) { win.send("export_font"); } },
             { label: "Import font from image (GIF/PNG)\u2026", id: "import_font", click(item) { win.send("import_font"); } },
             { type: "separator" },
-            { label: "How to make yourn own character set", id: "customfont_tutorial", click(item) { electron.shell.openExternal("https://blog.glyphdrawing.club/moebius-ansi-ascii-art-editor-with-custom-font-support"); } },
-
         ]
     };
 }

--- a/app/moebius.js
+++ b/app/moebius.js
@@ -104,6 +104,7 @@ async function open_file(file) {
     const win = await new_document_window();
     win.send("open_file", file);
 }
+electron.ipcMain.on("open_file", (event, {file}) => open_file(file));
 
 function open_in_new_window(win) {
     if (win && docs[win.id].open_in_current_window) {


### PR DESCRIPTION
This PR adds support for dragging and dropping files from the desktop into the editor window. #10 

- Dropping a ans/xbin/bin will display a prompt asking to open the file in the current window or a new window
- Dropping a png/jpeg will display a prompt asking to open the file as a reference image
- Dropping a font file will display a prompt asking to load the font

I also removed a dead link to glyphdrawing.club

This could be improved in the future by handling dropping multiple files at once, or displaying a visual indicator by highlighting the window when the mouse is dragging over the window.

[Screen Recording 2025-01-25 at 10.31.26 PM.webm](https://github.com/user-attachments/assets/9fcb509b-6108-4a47-9b09-d4bb97da9cc9)
