### PR TITLE
Add ability to open reference images in separate windows

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -546,6 +546,7 @@ function view_menu_template(win) {
                 ]
             },
             { type: "separator" },
+            { label: "Open Reference In Window\u2026", id: "open_reference_window", click(item) { event.emit("open_reference_window", win); } },
             { label: "Open Reference Image\u2026", id: "open_reference_image", accelerator: "CmdorCtrl+Shift+O", click(item) { win.send("open_reference_image"); } },
             { label: "Toggle Reference Image", id: "toggle_reference_image", accelerator: "Ctrl+Tab", click(item) { win.send("toggle_reference_image", item.checked); }, enabled: false, type: "checkbox", checked: true },
             { label: "Clear", id: "clear_reference_image", click(item) { win.send("clear_reference_image"); }, enabled: false },

--- a/app/moebius.js
+++ b/app/moebius.js
@@ -13,6 +13,7 @@ const frameless = darwin ? { frame: false, titleBarStyle: "hiddenInset" } : { fr
 let prevent_splash_screen_at_startup = false;
 let splash_screen;
 const discord = require("./discord");
+const {new_win} = require("./window");
 
 // This switch is required for <input type="color"> to utilize the OS color
 // picker, which is nicer than the one that's provided by chromium. At some
@@ -141,6 +142,33 @@ async function preferences() {
 }
 menu.on("preferences", preferences);
 electron.ipcMain.on("preferences", (event) => preferences());
+
+async function open_reference_window(win) {
+    const files = electron.dialog.showOpenDialogSync(win,
+        {
+            filters: [{
+                name: "Images",
+                extensions: ["png", "jpg", "jpeg"]
+            }],
+            properties: ["openFile", "multiSelections"]
+        });
+
+    if (!files) return;
+    for (const file of files) {
+        let reference = await new_win(
+            file,
+            {
+                width: 480,
+                height: 340,
+                parent: win,
+                maximizable: false,
+                minimizable: false,
+                fullscreenable: false,
+                resizable: true,
+            });
+    }
+}
+menu.on("open_reference_window", open_reference_window);
 
 async function show_new_connection() {
     const new_connection = await window.static("app/html/new_connection.html", { width: 480, height: 340 }, touchbar.new_connection);

--- a/app/window.js
+++ b/app/window.js
@@ -47,4 +47,4 @@ function close_static(name) {
 
 // electron.ipcMain.on("konami_code", (event, opts) => console.log("Konami!"));
 
-module.exports = {new_doc, new_modal, static, close_static};
+module.exports = {new_doc, new_modal, static, close_static, new_win};


### PR DESCRIPTION
This PR adds a new option to open reference images in a separate window on top of the editor.

Sometimes I want to use a reference, but I want it to be off to the side instead of directly underneath the text. This allows me to do so in a single monitor setup without needing to constantly tab between the active windows. You can open as many as you want and control them individually.

[Screen Recording 2025-01-28 at 4.33.20 PM.webm](https://github.com/user-attachments/assets/4e2fd46a-19ac-4349-99cd-609dd29adb50)
