### PR TITLE
Fixes scrolling for 200% zoom.

### DIFF
--- a/app/css/document.css
+++ b/app/css/document.css
@@ -344,7 +344,8 @@ body.dark #preview {
 }
 #canvas_container.canvas_zoom {
     transform: scale(2);
-    transform-origin: top;
+    transform-origin: top left;
+    margin: 0;
 }
 .hidden {
     display: none !important;

--- a/app/document/ui/canvas.js
+++ b/app/document/ui/canvas.js
@@ -1,6 +1,7 @@
 const doc = require("../doc");
 const chat = require("./chat");
 const cursor = require("../tools/cursor");
+
 let interval, render;
 let mouse_button = false;
 
@@ -44,10 +45,14 @@ function update_frame() {
     const viewport = $("viewport");
     const view_rect = viewport.getBoundingClientRect();
     const view_frame = $("view_frame");
+    const canvas_zoom_toggled = $("canvas_container").classList.contains("canvas_zoom");
+
     if (render) {
-        const scale_factor = render.width / 260;
+        let scale_factor = render.width / 260;
+        if (canvas_zoom_toggled) scale_factor *= 2;
+
         const width = Math.min(Math.ceil(view_rect.width / scale_factor), 260);
-        const height = Math.min(Math.ceil(view_rect.height / scale_factor), render.height / scale_factor);
+        const height = Math.min(Math.ceil(view_rect.height / scale_factor), render.height / (render.width / 260));
         const top = Math.ceil(viewport.scrollTop / scale_factor);
         const left = Math.ceil(viewport.scrollLeft / scale_factor);
         const preview = $("preview");
@@ -89,11 +94,13 @@ function add(new_render) {
 function update_with_mouse_pos(client_x, client_y) {
     const preview = $("preview");
     const viewport = $("viewport");
+    const canvas_zoom_toggled = $("canvas_container").classList.contains("canvas_zoom");
     const preview_rect = preview.getBoundingClientRect();
     const viewport_rect = viewport.getBoundingClientRect();
     const x = client_x - preview_rect.left - 20 + preview.scrollLeft;
     const y = client_y - preview_rect.top + preview.scrollTop;
-    const scale_factor = render.width / 260;
+    let scale_factor = render.width / 260;
+    if (canvas_zoom_toggled) scale_factor *= 2;
     const half_view_width = viewport_rect.width / scale_factor / 2;
     const half_view_height = viewport_rect.height / scale_factor / 2;
     viewport.scrollLeft = Math.floor((x - half_view_width) * scale_factor);

--- a/app/document/ui/ui.js
+++ b/app/document/ui/ui.js
@@ -4,7 +4,8 @@ const doc = require("../doc");
 const palette = require("../palette");
 const keyboard = require("../input/keyboard");
 const events = require("events");
-let interval, guide_columns, guide_rows;
+const chat = require("./chat")
+let interval, guide_columns, guide_rows, grid_columns;
 let canvas_zoom_toggled = false;
 
 function $(name) {
@@ -273,6 +274,7 @@ function canvas_zoom_toggle() {
     } else {
         $("canvas_container").classList.remove("canvas_zoom");
     }
+    chat.emit("update_frame");
     send("update_menu_checkboxes", { canvas_zoom_toggle: canvas_zoom_toggled });
 }
 


### PR DESCRIPTION
This PR fixes a couple of bugs with the "View canvas at 200%" option:

1. If the window was not large enough to display the whole canvas zoomed in, you could not scroll all the way to the left of the canvas. This is because centering with `margin: 0 auto` does not work properly when you apply `transform: scale(2)` to it. 
2. The preview window was broken when zoomed in, the box outlined the wrong section of the canvas and you couldn't click and drag it around properly.

The one trade-off is that I had to make is disabling the horizontal centering when at 200% zoom. So the canvas will appear on the left side instead of centered in the window. I messed around with it for a long time and I just couldn't get the CSS to work otherwise without breaking something else. This is really only noticeable if you have a large monitor though.

