### PR TITLE
Add outline/border to the brush tool

### DIFF
--- a/app/document/tools/brush.js
+++ b/app/document/tools/brush.js
@@ -4,8 +4,10 @@ const mouse = require("../input/mouse");
 const keyboard = require("../input/keyboard");
 const palette = require("../palette");
 const brushes = require("./brushes");
+const {Overlay} = require("./overlay");
 const {on} = require("../../senders");
 let enabled = false;
+let overlay;
 let chunked_undo = true;
 let tab_held_down = false;
 let last_xy;
@@ -13,15 +15,77 @@ let last_xy;
 tools.on("start", (mode) => {
     enabled = (mode == tools.modes.BRUSH);
     if (enabled) {
-        toolbar.show_brush();
-    } else if (tab_held_down) {
-        tab_held_down = false;
+        toolbar.show_brush()
+    } else {
+        if (tab_held_down) {
+            tab_held_down = false;
+        }
+        destroy_overlay();
     }
 });
+
+function destroy_overlay() {
+    if (overlay) {
+        overlay.destroy();
+        overlay = null;
+    }
+}
+
+function draw_cursor_outline(x, y, half_y) {
+    const font = doc.font;
+    const { fg, bg } = palette;
+
+    let height_scalar = 1;
+    if (toolbar.mode === toolbar.modes.HALF_BLOCK) {
+        y = half_y;
+        height_scalar = 2;
+    }
+
+    // Display the brush outline as long as part of the brush is in-bounds
+    const is_legal = (
+        x >= 1 - Math.ceil(toolbar.brush_size / 2 )
+        && x < doc.columns + Math.floor(toolbar.brush_size / 2)
+        && y >= 1 - Math.ceil(toolbar.brush_size / 2 )
+        && y < (doc.rows * height_scalar) + Math.floor(toolbar.brush_size / 2)
+    );
+
+    if (!is_legal) {
+        destroy_overlay();
+        return;
+    }
+
+    if (!overlay) {
+        overlay = new Overlay();
+        overlay.canvas.style.opacity = "1";
+        overlay.canvas.style.outline = "1px solid rgba(255, 255, 255, 0.8)";
+    }
+
+    let sx = (x - Math.floor(toolbar.brush_size / 2)) * font.width
+    let sy = (y - Math.floor(toolbar.brush_size / 2)) * (font.height / height_scalar)
+    let width = toolbar.brush_size * font.width
+    let height = toolbar.brush_size * font.height / height_scalar;
+
+    overlay.update(sx, sy, width, height);
+
+    if (toolbar.mode === toolbar.modes.CUSTOM_BLOCK) {
+        for (let x = 0; x < toolbar.brush_size; x++) {
+            for (let y = 0; y < toolbar.brush_size; y++) {
+                font.draw(overlay.ctx, {code: toolbar.custom_block_index, fg, bg}, x * font.width, y * font.height);
+            }
+        }
+    }
+}
+
+function mouse_move(x, y, half_y, is_legal, button, shift_key) {
+    if (!enabled) return;
+    draw_cursor_outline(x, y, half_y);
+}
 
 function mouse_handler(skip_first) {
     return (x, y, half_y, is_legal, button, shift_key) => {
         if (!enabled) return;
+        draw_cursor_outline(x, y, half_y);
+
         if (!chunked_undo || !skip_first) doc.start_undo();
         mouse.start_drawing();
         const {fg, bg} = palette;
@@ -98,6 +162,11 @@ document.addEventListener("keyup", (event) => {
 mouse.on("down", mouse_handler(false));
 mouse.on("draw", mouse_handler(true));
 mouse.on("up", mouse_up);
+mouse.on("move", mouse_move);
+mouse.on("out", () => {
+    if (!enabled) return;
+    destroy_overlay();
+});
 
 function select_attribute() {
     if (!enabled) return;


### PR DESCRIPTION
This PR adds a border around the cursor when using the brush tool.

This is helpful to visualize where the brush is positioned relative to the grid underneath, especially when the brush size is larger than 1 or when working in half block mode.

The border is displayed in all modes including half block, custom block, and shading. In custom block mode, the character is also displayed underneath the cursor.

I didn't make this a setting because I couldn't think of any reasons where I *wouldn't* want to have this turned on. But I'm open to feedback on this because I don't know how everyone else is using the brush tool.

[Screen Recording 2025-02-04 at 4.11.29 PM.webm](https://github.com/user-attachments/assets/bf47539c-2b57-4d53-94f8-493056f5ad10)
