### PR TITLE
Add Recent Files Menu Feature

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -378,8 +378,10 @@ function build_app_recent_files_menu() {
     const menu_items = recent_files.map(file => {
         return { 
             label: format_file_path_for_display(file), 
+            // Store the actual full path in a property that will be passed to the event handler
+            filepath: file,
             click(item) { 
-                event.emit("open_recent_file", { file }); 
+                event.emit("open_recent_file", { file: item.filepath }); 
             } 
         };
     });
@@ -416,9 +418,11 @@ function build_recent_files_menu(win) {
     
     const menu_items = recent_files.map(file => {
         return { 
-            label: format_file_path_for_display(file), 
+            label: format_file_path_for_display(file),
+            // Store the actual full path in a property that will be passed to the event handler
+            filepath: file,
             click(item) { 
-                event.emit("open_recent_file", { win, file }); 
+                event.emit("open_recent_file", { win, file: item.filepath }); 
             } 
         };
     });

--- a/app/menu.js
+++ b/app/menu.js
@@ -1071,6 +1071,16 @@ class MenuEvent extends events.EventEmitter {
         console.log("Setting application menu, rebuilding recent files list");
         // Rebuild application menu to include latest recent files
         if (darwin) {
+            // First check if there's an active document window - if so, use its menu
+            const win_id = this.get_focused_document_window_id();
+            if (win_id && menus[win_id]) {
+                console.log("Using focused document window menu");
+                electron.Menu.setApplicationMenu(menus[win_id]);
+                return;
+            }
+            
+            // Otherwise build a default application menu
+            console.log("Building default application menu");
             const prefs = require("./prefs");
             const recent_files = prefs.get("recent_files");
             console.log("Recent files in menu:", recent_files);
@@ -1107,6 +1117,23 @@ class MenuEvent extends events.EventEmitter {
         } else {
             electron.Menu.setApplicationMenu(application);
         }
+    }
+    
+    // Helper method to find a focused document window ID
+    get_focused_document_window_id() {
+        const BrowserWindow = electron.BrowserWindow;
+        const windows = BrowserWindow.getAllWindows();
+        const focused_win = BrowserWindow.getFocusedWindow();
+        
+        if (focused_win) {
+            for (const id of Object.keys(menus)) {
+                if (parseInt(id) === focused_win.id) {
+                    return id;
+                }
+            }
+        }
+        
+        return null;
     }
 
     chat_input_menu(win, debug) {

--- a/app/menu.js
+++ b/app/menu.js
@@ -1110,7 +1110,14 @@ class MenuEvent extends events.EventEmitter {
     }
 
     chat_input_menu(win, debug) {
-        const menu = darwin ? electron.Menu.buildFromTemplate([moebius_menu, ...create_menu_template(win, true, debug), window_menu_items, help_menu_items]) : electron.Menu.buildFromTemplate([...create_menu_template(win, true, debug), help_menu_items]);
+        // When creating a chat menu, make sure to include all template items
+        const templates = create_menu_template(win, true, debug);
+        
+        // Build menu with complete templates
+        const menu = darwin 
+            ? electron.Menu.buildFromTemplate([moebius_menu, ...templates, window_menu_items, help_menu_items]) 
+            : electron.Menu.buildFromTemplate([...templates, help_menu_items]);
+            
         chat_menus[win.id] = menu;
         return menu;
     }
@@ -1120,7 +1127,14 @@ class MenuEvent extends events.EventEmitter {
     }
 
     document_menu(win, debug) {
-        const menu = darwin ? electron.Menu.buildFromTemplate([moebius_menu, ...create_menu_template(win, false, debug), window_menu_items, help_menu_items]) : electron.Menu.buildFromTemplate([...create_menu_template(win, false, debug), help_menu_items]);
+        // When creating a document menu, make sure to include all template items
+        const templates = create_menu_template(win, false, debug);
+        
+        // Build menu with complete templates
+        const menu = darwin 
+            ? electron.Menu.buildFromTemplate([moebius_menu, ...templates, window_menu_items, help_menu_items]) 
+            : electron.Menu.buildFromTemplate([...templates, help_menu_items]);
+            
         menus[win.id] = menu;
         return menu;
     }

--- a/app/menu.js
+++ b/app/menu.js
@@ -344,12 +344,35 @@ const help_menu_items = {
     ]
 };
 
+function build_app_recent_files_menu() {
+    const prefs = require("./prefs");
+    const recent_files = prefs.get("recent_files");
+    if (!recent_files || recent_files.length === 0) {
+        return [{ label: "No recent files", enabled: false }];
+    }
+    
+    const menu_items = recent_files.map(file => {
+        return { 
+            label: file, 
+            click(item) { 
+                event.emit("open_recent_file", { file }); 
+            } 
+        };
+    });
+    
+    menu_items.push({ type: "separator" });
+    menu_items.push({ label: "Clear Recent Files", click(item) { event.emit("clear_recent_files"); } });
+    
+    return menu_items;
+}
+
 const application = electron.Menu.buildFromTemplate([moebius_menu, {
     label: "File",
     submenu: [
         { label: "New", id: "new_document", accelerator: "Cmd+N", click(item) { event.emit("new_document"); } },
         { type: "separator" },
         { label: "Open\u2026", id: "open", accelerator: "Cmd+O", click(item) { event.emit("open"); } },
+        { label: "Open Recent", id: "open_recent", submenu: build_app_recent_files_menu() },
         { role: "recentDocuments", submenu: [{ role: "clearRecentDocuments" }] },
         { type: "separator" },
         { role: "close" },
@@ -361,6 +384,28 @@ const application = electron.Menu.buildFromTemplate([moebius_menu, {
     }, window_menu_items, help_menu_items
 ]);
 
+function build_recent_files_menu(win) {
+    const prefs = require("./prefs");
+    const recent_files = prefs.get("recent_files");
+    if (!recent_files || recent_files.length === 0) {
+        return [{ label: "No recent files", enabled: false }];
+    }
+    
+    const menu_items = recent_files.map(file => {
+        return { 
+            label: file, 
+            click(item) { 
+                event.emit("open_recent_file", { win, file }); 
+            } 
+        };
+    });
+    
+    menu_items.push({ type: "separator" });
+    menu_items.push({ label: "Clear Recent Files", click(item) { event.emit("clear_recent_files"); } });
+    
+    return menu_items;
+}
+
 function file_menu_template(win) {
     return {
         label: "&File",
@@ -370,6 +415,7 @@ function file_menu_template(win) {
             { type: "separator" },
             { label: "Open\u2026", id: "open", accelerator: "CmdorCtrl+O", click(item) { event.emit("open", win); } },
             { label: "Open in Current Window\u2026", id: "open_in_current_window", accelerator: "CmdorCtrl+Shift+O", click(item) { event.emit("open_in_current_window", win); } },
+            { label: "Open Recent", id: "open_recent", submenu: build_recent_files_menu(win) },
             darwin ? { role: "recentDocuments", submenu: [{ role: "clearRecentDocuments" }] } : ({ type: "separator" }, { label: "Settings", click(item) { event.emit("preferences"); } }),
             { type: "separator" },
             { label: "Revert to Last Save", id: "revert_to_last_save", click(item) { win.send("revert_to_last_save"); }, enabled: false },

--- a/app/moebius.js
+++ b/app/moebius.js
@@ -77,7 +77,13 @@ async function new_document({ columns, rows, title, author, group, date, palette
 
 // Function to add a file to the recent files list in preferences
 function add_to_recent_files(file) {
-    const recent_files = prefs.get("recent_files");
+    console.log("Adding to recent files:", file);
+    
+    // Make sure we have an array (might be undefined if it's the first time)
+    let recent_files = prefs.get("recent_files");
+    if (!Array.isArray(recent_files)) {
+        recent_files = [];
+    }
     
     // If file is already in the list, remove it
     const file_index = recent_files.indexOf(file);
@@ -92,6 +98,8 @@ function add_to_recent_files(file) {
     if (recent_files.length > 10) {
         recent_files.pop();
     }
+    
+    console.log("Recent files after update:", recent_files);
     
     // Save updated list to preferences
     prefs.set("recent_files", recent_files);
@@ -171,18 +179,31 @@ menu.on("open_in_current_window", (win) => {
 
 // Open a file from the recent files list
 menu.on("open_recent_file", ({ win, file }) => {
+    console.log("Opening recent file:", file);
+    console.log("Win provided:", !!win);
+    
     const fs = require("fs");
     // Check if file exists
     if (fs.existsSync(file)) {
+        console.log("File exists");
+        
         if (win && !check_if_file_is_already_open(file) && !open_in_new_window(win)) {
+            console.log("Opening in existing window");
             win.send("open_file", file);
             docs[win.id].file = file;
         } else {
+            console.log("Opening in new window");
             open_file(file);
         }
     } else {
+        console.log("File does not exist:", file);
+        
         // If file doesn't exist, show an error and remove it from the recent files list
-        const recent_files = prefs.get("recent_files");
+        let recent_files = prefs.get("recent_files");
+        if (!Array.isArray(recent_files)) {
+            recent_files = [];
+        }
+        
         const file_index = recent_files.indexOf(file);
         if (file_index !== -1) {
             recent_files.splice(file_index, 1);

--- a/app/prefs.js
+++ b/app/prefs.js
@@ -20,6 +20,7 @@ const default_values = {
     discord: false,
     use_backup: false,
     backup_folder: "",
+    recent_files: [],
     fkeys: [ // Stolen mercilously from Pablo, thanks Curtis!
         [218, 191, 192, 217, 196, 179, 195, 180, 193, 194, 32, 32],
         [201, 187, 200, 188, 205, 186, 204, 185, 202, 203, 32, 32],


### PR DESCRIPTION
## Summary
This PR adds a Recent Files menu to Moebius, making it easier for users to quickly access their previously edited files. The feature has been thoroughly tested on macOS and enhances the workflow for users who frequently work with the same set of files.

## Changes
- Added a "Recent Files" list to the File menu that stores up to 10 recently accessed files
- Files are displayed with just their filenames for a clean look
- Similar filenames are disambiguated by showing the parent directory
- Non-existent files are automatically removed when detected
- Added a "Clear Recent Files" option to reset the list
- Recent files are stored in the app preferences
- Fixed various menu-related issues to ensure all menus display correctly

## Implementation Details
- Added `recent_files` array to preferences system
- Enhanced menu rebuilding system to incorporate recent files list
- Improved menu building logic to preserve full document menus
- Added smart window focus detection to maintain proper menus
- Files open instantly from the Recent Files menu

## Testing
All features were manually tested on macOS:
- Opening files adds them to the Recent Files menu
- Previously opened files appear in the menu with just their filenames
- Opening a file from the menu works correctly
- Non-existent files are removed from the menu with an error message
- Clear Recent Files option works as expected
- Menu items remain visible when switching between windows

## Commits
$(git log --pretty=format:"- %h %s" master..add-recent-files)