### PR TITLE
Adding grid and guide hotkey toggles, updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Moebius XBIN is an XBIN Editor for MacOS, Linux and Windows. This is a forked ve
 - `Moebius XBIN GJ Edition` which originally was just me wanting to stop the function keys from re-mapping -- but now has become a bit more.
 
 ## Moebius XBIN GJ Edition:
+- Recent files support
 - Stops the function keys from being remapped when clicking in the character list.
 - Makes default font IBM VGA instead of TOPAZ 437 (preference)
 - Lets you use the character list picker to load the custom paint brush block.
@@ -15,6 +16,15 @@ Moebius XBIN is an XBIN Editor for MacOS, Linux and Windows. This is a forked ve
 - Adds a 1x1 drawing grid
 - Adds character code to status bar
 - Smaller character list (actual size of font vs 2x zoom previously)
+- Added hokey `CTRL+'` to toggle the drawing grid - Defaults to 1x1 grid when first toggled on
+- Added hotkey `CTRL+;` to toggle guides - Defaults to Smallscale guide (80x25) when first toggled on
+- Reference image tool by @michael-lazar
+- Fixes for BIN / XBIN encoding by @michael-lazar
+- Re-render drawing grid on font change by @michael-lazar
+- Drag and drop files from desktop by @michael-lazar
+- Add ability to open reference images in separate windows by @michael-lazar
+- Fixes scrolling for 200% zoom. by @michael-lazar
+- Add outline/border to the brush tool by @michael-lazar
 - ... more things to come perhaps!
 
 ## Download packages

--- a/app/document/input/keyboard.js
+++ b/app/document/input/keyboard.js
@@ -38,6 +38,16 @@ class KeyboardEvent extends events.EventEmitter {
                 return;
         }
         switch (event.key) {
+            case "'":
+            case "Quote":
+                this.emit("toggle_grid");
+                event.preventDefault();
+                return;
+            case ";":
+            case "Semicolon":
+                this.emit("toggle_guide");
+                event.preventDefault();
+                return;
             case "c": case "C":
                 this.emit("copy");
                 return;
@@ -140,8 +150,7 @@ class KeyboardEvent extends events.EventEmitter {
                 this.emit("move_charlist", "down");
                 event.preventDefault();
                 return;
-            }
-            
+        }
     }
 
     meta_key(event) {

--- a/app/document/ui/ui.js
+++ b/app/document/ui/ui.js
@@ -229,8 +229,27 @@ function rescale_guide() {
 }
 
 function toggle_drawinggrid(visible, columns) {
-    $("guide").classList.add("hidden");
-    send("uncheck_all_guides");
+    if (visible === undefined) {
+        // Toggle current grid state
+        const grid = $("drawing_grid");
+        const isHidden = grid.classList.contains("hidden");
+        if (isHidden) {
+            // Always default to 1x1 grid when toggling on, unless a different grid was previously set
+            if (!grid_columns) {
+                grid_columns = 1;
+                rescale_drawinggrid();
+                send("check_drawinggrid_1x1");
+            } else {
+                send("check_drawinggrid_" + grid_columns + "x" + (grid_columns / 2));
+            }
+            grid.classList.remove("hidden");
+        } else {
+            grid.classList.add("hidden");
+            uncheck_all_grids();
+        }
+        return;
+    }
+
     if (visible) {
         grid_columns = columns;
         rescale_drawinggrid();
@@ -242,7 +261,17 @@ function toggle_drawinggrid(visible, columns) {
         }
     } else {
         $("drawing_grid").classList.add("hidden");
+        uncheck_all_grids();
     }
+}
+
+function uncheck_all_grids() {
+    send("uncheck_drawinggrid_1x1");
+    send("uncheck_drawinggrid_4x2");
+    send("uncheck_drawinggrid_6x3");
+    send("uncheck_drawinggrid_8x4");
+    send("uncheck_drawinggrid_12x6");
+    send("uncheck_drawinggrid_16x8");
 }
 
 function rescale_drawinggrid() {
@@ -272,12 +301,34 @@ function rescale_drawinggrid() {
     }
 }
 
+function toggle_guide() {
+    const guide = $("guide");
+    if (guide.classList.contains("hidden")) {
+        // If no guide type was previously set, default to Smallscale guide
+        if (!guide_columns || !guide_rows) {
+            guide_columns = 80;
+            guide_rows = 25;
+            rescale_guide();
+            send("check_smallscale_guide");
+        }
+        guide.classList.remove("hidden");
+    } else {
+        guide.classList.add("hidden");
+        send("uncheck_all_guides");
+    }
+}
+
 on("toggle_smallscale_guide", (event, visible) => toggle_smallscale_guide(visible));
 on("toggle_square_guide", (event, visible) => toggle_square_guide(visible));
 on("toggle_instagram_guide", (event, visible) => toggle_instagram_guide(visible));
 on("toggle_file_id_guide", (event, visible) => toggle_file_id_guide(visible));
 on("toggle_petscii_guide", (event, visible) => toggle_petscii_guide(visible));
 on("toggle_drawinggrid", (event, visible, columns) => toggle_drawinggrid(visible, columns));
+
+// Add keyboard grid toggle handler
+keyboard.on("toggle_grid", () => toggle_drawinggrid());
+// Add keyboard guide toggle handler
+keyboard.on("toggle_guide", () => toggle_guide());
 
 doc.on("render", () => rescale_guide());
 doc.on("render", () => rescale_drawinggrid());


### PR DESCRIPTION
- Added hokey `CTRL+'` to toggle the drawing grid - Defaults to 1x1 grid when first toggled on
- Added hotkey `CTRL+;` to toggle guides - Defaults to Smallscale guide (80x25) when first toggled on

Closes #9 